### PR TITLE
Implement player CRUD

### DIFF
--- a/app/Http/Controllers/PlayerController.php
+++ b/app/Http/Controllers/PlayerController.php
@@ -1,0 +1,48 @@
+<?php
+namespace App\Http\Controllers;
+
+use App\Models\Player;
+use Illuminate\Http\Request;
+
+class PlayerController extends Controller
+{
+    public function index()
+    {
+        $players = Player::all();
+        return view('players.index', compact('players'));
+    }
+
+    public function create()
+    {
+        return view('players.create');
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name' => 'required|string|max:255|unique:players,name',
+        ]);
+        Player::create($data);
+        return redirect()->route('players.index');
+    }
+
+    public function edit(Player $player)
+    {
+        return view('players.edit', compact('player'));
+    }
+
+    public function update(Request $request, Player $player)
+    {
+        $data = $request->validate([
+            'name' => 'required|string|max:255|unique:players,name,' . $player->id,
+        ]);
+        $player->update($data);
+        return redirect()->route('players.index');
+    }
+
+    public function destroy(Player $player)
+    {
+        $player->delete();
+        return redirect()->route('players.index');
+    }
+}

--- a/app/Models/Player.php
+++ b/app/Models/Player.php
@@ -4,6 +4,13 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Model;
 
 class Player extends Model {
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = ['name'];
+
     public function dailyStats()   { return $this->hasMany(DailyStat::class); }
     public function weeklyStats()  { return $this->hasMany(WeeklyStat::class); }
     public function monthlyStats() { return $this->hasMany(MonthlyStat::class); }

--- a/resources/views/players/create.blade.php
+++ b/resources/views/players/create.blade.php
@@ -1,0 +1,12 @@
+@extends('layouts.app')
+@section('content')
+    <h1>Novo Jogador</h1>
+    <form action="{{ route('players.store') }}" method="POST">
+        @csrf
+        <div class="mb-3">
+            <label class="form-label">Nome</label>
+            <input type="text" name="name" class="form-control" required>
+        </div>
+        <button type="submit" class="btn btn-primary">Salvar</button>
+    </form>
+@endsection

--- a/resources/views/players/edit.blade.php
+++ b/resources/views/players/edit.blade.php
@@ -1,0 +1,13 @@
+@extends('layouts.app')
+@section('content')
+    <h1>Editar Jogador</h1>
+    <form action="{{ route('players.update', $player) }}" method="POST">
+        @csrf
+        @method('PUT')
+        <div class="mb-3">
+            <label class="form-label">Nome</label>
+            <input type="text" name="name" value="{{ old('name', $player->name) }}" class="form-control" required>
+        </div>
+        <button type="submit" class="btn btn-primary">Atualizar</button>
+    </form>
+@endsection

--- a/resources/views/players/index.blade.php
+++ b/resources/views/players/index.blade.php
@@ -1,0 +1,30 @@
+@extends('layouts.app')
+@section('content')
+    <h1>Jogadores</h1>
+    <a href="{{ route('players.create') }}" class="btn btn-primary mb-2">Novo Jogador</a>
+    <table class="table table-bordered">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Nome</th>
+                <th>Ações</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($players as $player)
+                <tr>
+                    <td>{{ $player->id }}</td>
+                    <td>{{ $player->name }}</td>
+                    <td>
+                        <a href="{{ route('players.edit', $player) }}" class="btn btn-sm btn-secondary">Editar</a>
+                        <form action="{{ route('players.destroy', $player) }}" method="POST" style="display:inline-block;">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit" class="btn btn-sm btn-danger">Excluir</button>
+                        </form>
+                    </td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,9 +1,11 @@
 <?php
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\WeeklyStatController;
+use App\Http\Controllers\PlayerController;
 
 Route::get('/', function () {
     return '<h1>Laravel está rodando!</h1>';
 });
 
 Route::resource('weekly-stats', WeeklyStatController::class);
+Route::resource('players', PlayerController::class);

--- a/tests/Feature/PlayerCrudTest.php
+++ b/tests/Feature/PlayerCrudTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Player;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PlayerCrudTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_can_view_players_index(): void
+    {
+        $response = $this->get('/players');
+        $response->assertStatus(200);
+    }
+
+    public function test_can_create_player(): void
+    {
+        $response = $this->post('/players', ['name' => 'Teste']);
+        $response->assertRedirect('/players');
+        $this->assertDatabaseHas('players', ['name' => 'Teste']);
+    }
+}


### PR DESCRIPTION
## Summary
- create `PlayerController` to handle player resource actions
- make `Player` model mass assignable
- register player routes
- add player blade templates for listing, creating and editing
- cover player routes with a feature test

## Testing
- `composer test` *(fails: composer not installed)*
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68653a9f32a0832d91573495702c38ec