### PR TITLE
Implement Matches CRUD

### DIFF
--- a/app/Http/Controllers/MatchController.php
+++ b/app/Http/Controllers/MatchController.php
@@ -1,0 +1,82 @@
+<?php
+namespace App\Http\Controllers;
+
+use App\Models\Game;
+use App\Models\MatchPlayer;
+use App\Models\Player;
+use Illuminate\Http\Request;
+
+class MatchController extends Controller
+{
+    public function index()
+    {
+        $matches = Game::all();
+        return view('matches.index', compact('matches'));
+    }
+
+    public function create()
+    {
+        $players = Player::all();
+        return view('matches.create', compact('players'));
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate(['date' => 'required|date']);
+        $match = Game::create($data);
+        foreach ($request->input('players', []) as $playerId => $stats) {
+            MatchPlayer::create([
+                'match_id' => $match->id,
+                'player_id' => $playerId,
+                'kills' => $stats['kills'] ?? 0,
+                'assists' => $stats['assists'] ?? 0,
+                'damage' => $stats['damage'] ?? 0,
+                'survived' => isset($stats['survived']),
+                'rescue' => $stats['rescue'] ?? 0,
+                'recall' => $stats['recall'] ?? 0,
+                'score' => $stats['score'] ?? 0,
+                'mvp' => isset($stats['mvp']),
+                'coffee' => $stats['coffee'] ?? 0,
+                'played' => isset($stats['played']),
+            ]);
+        }
+        return redirect()->route('matches.index');
+    }
+
+    public function edit(Game $match)
+    {
+        $players = Player::all();
+        $match->load('playerStats');
+        return view('matches.edit', compact('match', 'players'));
+    }
+
+    public function update(Request $request, Game $match)
+    {
+        $data = $request->validate(['date' => 'required|date']);
+        $match->update($data);
+        $match->playerStats()->delete();
+        foreach ($request->input('players', []) as $playerId => $stats) {
+            MatchPlayer::create([
+                'match_id' => $match->id,
+                'player_id' => $playerId,
+                'kills' => $stats['kills'] ?? 0,
+                'assists' => $stats['assists'] ?? 0,
+                'damage' => $stats['damage'] ?? 0,
+                'survived' => isset($stats['survived']),
+                'rescue' => $stats['rescue'] ?? 0,
+                'recall' => $stats['recall'] ?? 0,
+                'score' => $stats['score'] ?? 0,
+                'mvp' => isset($stats['mvp']),
+                'coffee' => $stats['coffee'] ?? 0,
+                'played' => isset($stats['played']),
+            ]);
+        }
+        return redirect()->route('matches.index');
+    }
+
+    public function destroy(Game $match)
+    {
+        $match->delete();
+        return redirect()->route('matches.index');
+    }
+}

--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -1,0 +1,10 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Game extends Model {
+    protected $table = 'matches';
+    protected $fillable = ['date'];
+    public function playerStats() { return $this->hasMany(MatchPlayer::class); }
+}

--- a/app/Models/MatchPlayer.php
+++ b/app/Models/MatchPlayer.php
@@ -1,0 +1,26 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use App\Models\Game;
+
+class MatchPlayer extends Model {
+    protected $table = 'match_players';
+    protected $fillable = [
+        'match_id',
+        'player_id',
+        'kills',
+        'assists',
+        'damage',
+        'survived',
+        'rescue',
+        'recall',
+        'score',
+        'mvp',
+        'coffee',
+        'played'
+    ];
+
+    public function match() { return $this->belongsTo(Game::class, 'match_id'); }
+    public function player() { return $this->belongsTo(Player::class); }
+}

--- a/database/migrations/2025_07_02_000004_create_matches_table.php
+++ b/database/migrations/2025_07_02_000004_create_matches_table.php
@@ -1,0 +1,17 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up() {
+        Schema::create('matches', function (Blueprint $table) {
+            $table->id();
+            $table->date('date');
+            $table->timestamps();
+        });
+    }
+    public function down() {
+        Schema::dropIfExists('matches');
+    }
+};

--- a/database/migrations/2025_07_02_000005_create_match_players_table.php
+++ b/database/migrations/2025_07_02_000005_create_match_players_table.php
@@ -1,0 +1,28 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up() {
+        Schema::create('match_players', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('match_id')->constrained()->onDelete('cascade');
+            $table->foreignId('player_id')->constrained()->onDelete('cascade');
+            $table->integer('kills');
+            $table->integer('assists');
+            $table->integer('damage');
+            $table->boolean('survived');
+            $table->integer('rescue');
+            $table->integer('recall');
+            $table->float('score');
+            $table->boolean('mvp');
+            $table->integer('coffee');
+            $table->boolean('played');
+            $table->timestamps();
+        });
+    }
+    public function down() {
+        Schema::dropIfExists('match_players');
+    }
+};

--- a/resources/views/matches/create.blade.php
+++ b/resources/views/matches/create.blade.php
@@ -1,0 +1,27 @@
+@extends('layouts.app')
+@section('content')
+    <h1>Nova Partida</h1>
+    <form action="{{ route('matches.store') }}" method="POST">
+        @csrf
+        <div class="mb-3">
+            <label class="form-label">Dia</label>
+            <input type="date" name="date" class="form-control" required>
+        </div>
+        @foreach($players as $player)
+            <h4>{{ $player->name }}</h4>
+            <div class="row mb-2">
+                <div class="col"><input type="number" name="players[{{ $player->id }}][kills]" class="form-control" placeholder="Abates"></div>
+                <div class="col"><input type="number" name="players[{{ $player->id }}][assists]" class="form-control" placeholder="Assistências"></div>
+                <div class="col"><input type="number" name="players[{{ $player->id }}][damage]" class="form-control" placeholder="Dano"></div>
+                <div class="col"><input type="checkbox" name="players[{{ $player->id }}][survived]" value="1"> Sobreviveu</div>
+                <div class="col"><input type="number" name="players[{{ $player->id }}][rescue]" class="form-control" placeholder="Resgate"></div>
+                <div class="col"><input type="number" name="players[{{ $player->id }}][recall]" class="form-control" placeholder="Chamar de volta"></div>
+                <div class="col"><input type="number" step="0.01" name="players[{{ $player->id }}][score]" class="form-control" placeholder="Pontuação"></div>
+                <div class="col"><input type="checkbox" name="players[{{ $player->id }}][mvp]" value="1"> MVP</div>
+                <div class="col"><input type="number" name="players[{{ $player->id }}][coffee]" class="form-control" placeholder="Café"></div>
+                <div class="col"><input type="checkbox" name="players[{{ $player->id }}][played]" value="1" checked> Jogou?</div>
+            </div>
+        @endforeach
+        <button type="submit" class="btn btn-primary">Salvar</button>
+    </form>
+@endsection

--- a/resources/views/matches/edit.blade.php
+++ b/resources/views/matches/edit.blade.php
@@ -1,0 +1,29 @@
+@extends('layouts.app')
+@section('content')
+    <h1>Editar Partida</h1>
+    <form action="{{ route('matches.update', $match) }}" method="POST">
+        @csrf
+        @method('PUT')
+        <div class="mb-3">
+            <label class="form-label">Dia</label>
+            <input type="date" name="date" class="form-control" value="{{ $match->date }}" required>
+        </div>
+        @foreach($players as $player)
+            @php $stat = $match->playerStats->firstWhere('player_id', $player->id); @endphp
+            <h4>{{ $player->name }}</h4>
+            <div class="row mb-2">
+                <div class="col"><input type="number" name="players[{{ $player->id }}][kills]" class="form-control" placeholder="Abates" value="{{ $stat->kills ?? '' }}"></div>
+                <div class="col"><input type="number" name="players[{{ $player->id }}][assists]" class="form-control" placeholder="Assistências" value="{{ $stat->assists ?? '' }}"></div>
+                <div class="col"><input type="number" name="players[{{ $player->id }}][damage]" class="form-control" placeholder="Dano" value="{{ $stat->damage ?? '' }}"></div>
+                <div class="col"><input type="checkbox" name="players[{{ $player->id }}][survived]" value="1" {{ isset($stat) && $stat->survived ? 'checked' : '' }}> Sobreviveu</div>
+                <div class="col"><input type="number" name="players[{{ $player->id }}][rescue]" class="form-control" placeholder="Resgate" value="{{ $stat->rescue ?? '' }}"></div>
+                <div class="col"><input type="number" name="players[{{ $player->id }}][recall]" class="form-control" placeholder="Chamar de volta" value="{{ $stat->recall ?? '' }}"></div>
+                <div class="col"><input type="number" step="0.01" name="players[{{ $player->id }}][score]" class="form-control" placeholder="Pontuação" value="{{ $stat->score ?? '' }}"></div>
+                <div class="col"><input type="checkbox" name="players[{{ $player->id }}][mvp]" value="1" {{ isset($stat) && $stat->mvp ? 'checked' : '' }}> MVP</div>
+                <div class="col"><input type="number" name="players[{{ $player->id }}][coffee]" class="form-control" placeholder="Café" value="{{ $stat->coffee ?? '' }}"></div>
+                <div class="col"><input type="checkbox" name="players[{{ $player->id }}][played]" value="1" {{ isset($stat) && $stat->played ? 'checked' : '' }}> Jogou?</div>
+            </div>
+        @endforeach
+        <button type="submit" class="btn btn-primary">Salvar</button>
+    </form>
+@endsection

--- a/resources/views/matches/index.blade.php
+++ b/resources/views/matches/index.blade.php
@@ -1,0 +1,30 @@
+@extends('layouts.app')
+@section('content')
+    <h1>Partidas</h1>
+    <a href="{{ route('matches.create') }}" class="btn btn-primary mb-2">Nova Partida</a>
+    <table class="table table-bordered">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Dia</th>
+                <th>Ações</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($matches as $match)
+                <tr>
+                    <td>{{ $match->id }}</td>
+                    <td>{{ $match->date }}</td>
+                    <td>
+                        <a href="{{ route('matches.edit', $match) }}" class="btn btn-sm btn-secondary">Editar</a>
+                        <form action="{{ route('matches.destroy', $match) }}" method="POST" style="display:inline-block;">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit" class="btn btn-sm btn-danger">Excluir</button>
+                        </form>
+                    </td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\WeeklyStatController;
 use App\Http\Controllers\PlayerController;
+use App\Http\Controllers\MatchController;
 
 Route::get('/', function () {
     return '<h1>Laravel está rodando!</h1>';
@@ -9,3 +10,4 @@ Route::get('/', function () {
 
 Route::resource('weekly-stats', WeeklyStatController::class);
 Route::resource('players', PlayerController::class);
+Route::resource('matches', MatchController::class);

--- a/tests/Feature/MatchCrudTest.php
+++ b/tests/Feature/MatchCrudTest.php
@@ -1,0 +1,31 @@
+<?php
+namespace Tests\Feature;
+
+use App\Models\Game;
+use App\Models\Player;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class MatchCrudTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_can_view_matches_index(): void
+    {
+        $response = $this->get('/matches');
+        $response->assertStatus(200);
+    }
+
+    public function test_can_create_match(): void
+    {
+        $player = Player::create(['name' => 'Jogador']);
+        $response = $this->post('/matches', [
+            'date' => '2024-01-01',
+            'players' => [
+                $player->id => [ 'kills' => 1 ]
+            ]
+        ]);
+        $response->assertRedirect('/matches');
+        $this->assertDatabaseHas('matches', ['date' => '2024-01-01']);
+    }
+}


### PR DESCRIPTION
## Summary
- add Match CRUD implementation
- create models and migrations for matches and players stats
- set up controller and Blade templates for managing matches
- cover new functionality with a feature test

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_68653ddea818832da1c5eedc6eca352d