### PR TITLE
Ajuste campos de partida e criação de gráficos

### DIFF
--- a/app/Http/Controllers/ChartController.php
+++ b/app/Http/Controllers/ChartController.php
@@ -1,0 +1,23 @@
+<?php
+namespace App\Http\Controllers;
+
+use App\Models\MatchPlayer;
+use Illuminate\Support\Facades\DB;
+
+class ChartController extends Controller
+{
+    public function index()
+    {
+        $data = MatchPlayer::join('players', 'players.id', '=', 'match_players.player_id')
+            ->selectRaw('players.name as name, SUM(match_players.score) as total_score, SUM(match_players.coffee) as coffee_count, SUM(match_players.mvp) as mvp_count')
+            ->groupBy('players.name')
+            ->get();
+
+        $labels = $data->pluck('name');
+        $scores = $data->pluck('total_score');
+        $coffees = $data->pluck('coffee_count');
+        $mvps = $data->pluck('mvp_count');
+
+        return view('charts.index', compact('labels', 'scores', 'coffees', 'mvps'));
+    }
+}

--- a/app/Http/Controllers/MatchController.php
+++ b/app/Http/Controllers/MatchController.php
@@ -31,12 +31,12 @@ class MatchController extends Controller
                 'kills' => $stats['kills'] ?? 0,
                 'assists' => $stats['assists'] ?? 0,
                 'damage' => $stats['damage'] ?? 0,
-                'survived' => isset($stats['survived']),
+                'survived' => $stats['survived'] ?? 0,
                 'rescue' => $stats['rescue'] ?? 0,
                 'recall' => $stats['recall'] ?? 0,
                 'score' => $stats['score'] ?? 0,
                 'mvp' => isset($stats['mvp']),
-                'coffee' => $stats['coffee'] ?? 0,
+                'coffee' => isset($stats['coffee']),
                 'played' => isset($stats['played']),
             ]);
         }
@@ -62,12 +62,12 @@ class MatchController extends Controller
                 'kills' => $stats['kills'] ?? 0,
                 'assists' => $stats['assists'] ?? 0,
                 'damage' => $stats['damage'] ?? 0,
-                'survived' => isset($stats['survived']),
+                'survived' => $stats['survived'] ?? 0,
                 'rescue' => $stats['rescue'] ?? 0,
                 'recall' => $stats['recall'] ?? 0,
                 'score' => $stats['score'] ?? 0,
                 'mvp' => isset($stats['mvp']),
-                'coffee' => $stats['coffee'] ?? 0,
+                'coffee' => isset($stats['coffee']),
                 'played' => isset($stats['played']),
             ]);
         }

--- a/app/Models/MatchPlayer.php
+++ b/app/Models/MatchPlayer.php
@@ -20,6 +20,12 @@ class MatchPlayer extends Model {
         'coffee',
         'played'
     ];
+    protected $casts = [
+        'survived' => 'float',
+        'coffee' => 'boolean',
+        'mvp' => 'boolean',
+        'played' => 'boolean',
+    ];
 
     public function match() { return $this->belongsTo(Game::class, 'match_id'); }
     public function player() { return $this->belongsTo(Player::class); }

--- a/database/migrations/2025_07_02_000006_modify_match_players_survived_and_coffee_columns.php
+++ b/database/migrations/2025_07_02_000006_modify_match_players_survived_and_coffee_columns.php
@@ -1,0 +1,20 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up() {
+        Schema::table('match_players', function (Blueprint $table) {
+            $table->float('survived')->change();
+            $table->boolean('coffee')->change();
+        });
+    }
+
+    public function down() {
+        Schema::table('match_players', function (Blueprint $table) {
+            $table->boolean('survived')->change();
+            $table->integer('coffee')->change();
+        });
+    }
+};

--- a/resources/views/charts/index.blade.php
+++ b/resources/views/charts/index.blade.php
@@ -1,0 +1,33 @@
+@extends('layouts.app')
+@section('content')
+    <h1>Gráficos</h1>
+    <div class="mb-4">
+        <canvas id="scoreChart"></canvas>
+    </div>
+    <div class="mb-4">
+        <canvas id="coffeeChart"></canvas>
+    </div>
+    <div class="mb-4">
+        <canvas id="mvpChart"></canvas>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script>
+        const labels = @json($labels);
+        const scoreData = @json($scores);
+        const coffeeData = @json($coffees);
+        const mvpData = @json($mvps);
+
+        new Chart(document.getElementById('scoreChart'), {
+            type: 'bar',
+            data: {labels: labels, datasets: [{label: 'Pontuação', data: scoreData, backgroundColor: 'rgba(54,162,235,0.5)', borderColor: 'rgb(54,162,235)', borderWidth: 1}]}
+        });
+        new Chart(document.getElementById('coffeeChart'), {
+            type: 'pie',
+            data: {labels: labels, datasets: [{data: coffeeData, backgroundColor: labels.map((_,i)=>`hsl(${i*40},70%,70%)`)}]}
+        });
+        new Chart(document.getElementById('mvpChart'), {
+            type: 'pie',
+            data: {labels: labels, datasets: [{data: mvpData, backgroundColor: labels.map((_,i)=>`hsl(${i*40+20},70%,70%)`)}]}
+        });
+    </script>
+@endsection

--- a/resources/views/matches/create.blade.php
+++ b/resources/views/matches/create.blade.php
@@ -13,12 +13,12 @@
                 <div class="col"><input type="number" name="players[{{ $player->id }}][kills]" class="form-control" placeholder="Abates"></div>
                 <div class="col"><input type="number" name="players[{{ $player->id }}][assists]" class="form-control" placeholder="Assistências"></div>
                 <div class="col"><input type="number" name="players[{{ $player->id }}][damage]" class="form-control" placeholder="Dano"></div>
-                <div class="col"><input type="checkbox" name="players[{{ $player->id }}][survived]" value="1"> Sobreviveu</div>
+                <div class="col"><input type="number" step="0.01" name="players[{{ $player->id }}][survived]" class="form-control" placeholder="Sobreviveu"></div>
                 <div class="col"><input type="number" name="players[{{ $player->id }}][rescue]" class="form-control" placeholder="Resgate"></div>
                 <div class="col"><input type="number" name="players[{{ $player->id }}][recall]" class="form-control" placeholder="Chamar de volta"></div>
                 <div class="col"><input type="number" step="0.01" name="players[{{ $player->id }}][score]" class="form-control" placeholder="Pontuação"></div>
                 <div class="col"><input type="checkbox" name="players[{{ $player->id }}][mvp]" value="1"> MVP</div>
-                <div class="col"><input type="number" name="players[{{ $player->id }}][coffee]" class="form-control" placeholder="Café"></div>
+                <div class="col"><input type="checkbox" name="players[{{ $player->id }}][coffee]" value="1"> Café</div>
                 <div class="col"><input type="checkbox" name="players[{{ $player->id }}][played]" value="1" checked> Jogou?</div>
             </div>
         @endforeach

--- a/resources/views/matches/edit.blade.php
+++ b/resources/views/matches/edit.blade.php
@@ -15,12 +15,12 @@
                 <div class="col"><input type="number" name="players[{{ $player->id }}][kills]" class="form-control" placeholder="Abates" value="{{ $stat->kills ?? '' }}"></div>
                 <div class="col"><input type="number" name="players[{{ $player->id }}][assists]" class="form-control" placeholder="Assistências" value="{{ $stat->assists ?? '' }}"></div>
                 <div class="col"><input type="number" name="players[{{ $player->id }}][damage]" class="form-control" placeholder="Dano" value="{{ $stat->damage ?? '' }}"></div>
-                <div class="col"><input type="checkbox" name="players[{{ $player->id }}][survived]" value="1" {{ isset($stat) && $stat->survived ? 'checked' : '' }}> Sobreviveu</div>
+                <div class="col"><input type="number" step="0.01" name="players[{{ $player->id }}][survived]" class="form-control" placeholder="Sobreviveu" value="{{ $stat->survived ?? '' }}"></div>
                 <div class="col"><input type="number" name="players[{{ $player->id }}][rescue]" class="form-control" placeholder="Resgate" value="{{ $stat->rescue ?? '' }}"></div>
                 <div class="col"><input type="number" name="players[{{ $player->id }}][recall]" class="form-control" placeholder="Chamar de volta" value="{{ $stat->recall ?? '' }}"></div>
                 <div class="col"><input type="number" step="0.01" name="players[{{ $player->id }}][score]" class="form-control" placeholder="Pontuação" value="{{ $stat->score ?? '' }}"></div>
                 <div class="col"><input type="checkbox" name="players[{{ $player->id }}][mvp]" value="1" {{ isset($stat) && $stat->mvp ? 'checked' : '' }}> MVP</div>
-                <div class="col"><input type="number" name="players[{{ $player->id }}][coffee]" class="form-control" placeholder="Café" value="{{ $stat->coffee ?? '' }}"></div>
+                <div class="col"><input type="checkbox" name="players[{{ $player->id }}][coffee]" value="1" {{ isset($stat) && $stat->coffee ? 'checked' : '' }}> Café</div>
                 <div class="col"><input type="checkbox" name="players[{{ $player->id }}][played]" value="1" {{ isset($stat) && $stat->played ? 'checked' : '' }}> Jogou?</div>
             </div>
         @endforeach

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\WeeklyStatController;
 use App\Http\Controllers\PlayerController;
 use App\Http\Controllers\MatchController;
+use App\Http\Controllers\ChartController;
 
 Route::get('/', function () {
     return '<h1>Laravel está rodando!</h1>';
@@ -11,3 +12,4 @@ Route::get('/', function () {
 Route::resource('weekly-stats', WeeklyStatController::class);
 Route::resource('players', PlayerController::class);
 Route::resource('matches', MatchController::class);
+Route::get('charts', [ChartController::class, 'index'])->name('charts.index');


### PR DESCRIPTION
## Summary
- alterar campo `survived` para numérico e `coffee` para checkbox nos formulários
- atualizar MatchController para lidar com os novos tipos
- adicionar casts no modelo `MatchPlayer`
- criar migration para alterar colunas
- adicionar página e rota para exibir gráficos

## Testing
- `npm test` *(fails: Missing script)*
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865428dc6e0832d9b67477c94122f59