### PR TITLE
Create home page and update layout

### DIFF
--- a/resources/views/charts/index.blade.php
+++ b/resources/views/charts/index.blade.php
@@ -2,13 +2,15 @@
 @section('content')
     <h1>Gráficos</h1>
     <div class="mb-4">
-        <canvas id="scoreChart"></canvas>
+        <canvas id="scoreChart" style="max-width:500px;"></canvas>
     </div>
-    <div class="mb-4">
-        <canvas id="coffeeChart"></canvas>
-    </div>
-    <div class="mb-4">
-        <canvas id="mvpChart"></canvas>
+    <div class="row">
+        <div class="col-md-6 mb-4 text-center">
+            <canvas id="coffeeChart" width="300" height="300"></canvas>
+        </div>
+        <div class="col-md-6 mb-4 text-center">
+            <canvas id="mvpChart" width="300" height="300"></canvas>
+        </div>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script>

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -1,0 +1,6 @@
+@extends('layouts.app')
+@section('content')
+<div class="d-flex justify-content-center align-items-center" style="height:70vh;">
+    <h1 class="text-center">Bem vindo as estatísticas do PUBG da SAI</h1>
+</div>
+@endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -5,8 +5,19 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>
-    <div class="container mt-4">
-        @yield('content')
+    <div class="d-flex">
+        <nav class="bg-light p-3" style="min-width:200px;">
+            <ul class="nav flex-column">
+                <li class="nav-item"><a href="{{ url('/') }}" class="nav-link">Home</a></li>
+                <li class="nav-item"><a href="{{ route('players.index') }}" class="nav-link">Jogadores</a></li>
+                <li class="nav-item"><a href="{{ route('matches.index') }}" class="nav-link">Partidas</a></li>
+                <li class="nav-item"><a href="{{ route('weekly-stats.index') }}" class="nav-link">Estatísticas Semanais</a></li>
+                <li class="nav-item"><a href="{{ route('charts.index') }}" class="nav-link">Gráficos</a></li>
+            </ul>
+        </nav>
+        <main class="flex-grow-1 p-4">
+            @yield('content')
+        </main>
     </div>
 </body>
 </html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,7 +6,7 @@ use App\Http\Controllers\MatchController;
 use App\Http\Controllers\ChartController;
 
 Route::get('/', function () {
-    return '<h1>Laravel está rodando!</h1>';
+    return view('home');
 });
 
 Route::resource('weekly-stats', WeeklyStatController::class);


### PR DESCRIPTION
## Summary
- add a simple home view
- add sidebar navigation to the main layout
- update charts page to show pies side by side and smaller
- route `/` to the new home page

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686548313910832d98d93d2d75710495