### PR TITLE
Implement player totals in weekly stats

### DIFF
--- a/app/Http/Controllers/WeeklyStatController.php
+++ b/app/Http/Controllers/WeeklyStatController.php
@@ -5,8 +5,24 @@ use App\Models\WeeklyStat;
 use Illuminate\Http\Request;
 
 class WeeklyStatController extends Controller {
-    public function index() {
-        $stats = WeeklyStat::with('player')->get();
+    public function index()
+    {
+        $stats = WeeklyStat::join('players', 'players.id', '=', 'weekly_stats.player_id')
+            ->selectRaw('players.name as player_name, ' .
+                'SUM(weekly_stats.kills) as kills, ' .
+                'SUM(weekly_stats.assists) as assists, ' .
+                'SUM(weekly_stats.damage) as damage, ' .
+                'SUM(weekly_stats.survived_minutes) as survived_minutes, ' .
+                'SUM(weekly_stats.rescues) as rescues, ' .
+                'SUM(weekly_stats.call_back) as call_back, ' .
+                'SUM(weekly_stats.score) as score, ' .
+                'SUM(weekly_stats.mvp_count) as mvp_count, ' .
+                'SUM(weekly_stats.coffee_breaks) as coffee_breaks, ' .
+                'SUM(weekly_stats.matches_played) as matches_played')
+            ->groupBy('players.name')
+            ->orderBy('players.name')
+            ->get();
+
         return view('weekly-stats.index', compact('stats'));
     }
     public function create() {

--- a/resources/views/weekly-stats/index.blade.php
+++ b/resources/views/weekly-stats/index.blade.php
@@ -5,7 +5,6 @@
   <table class="table table-bordered">
     <thead>
       <tr>
-        <th>Semana</th>
         <th>Jogador</th>
         <th>Abates</th>
         <th>Assistências</th>
@@ -22,8 +21,7 @@
     <tbody>
       @foreach($stats as $stat)
       <tr>
-        <td>{{ $stat->week_start->format('d/m/Y') }}</td>
-        <td>{{ $stat->player->name }}</td>
+        <td>{{ $stat->player_name }}</td>
         <td>{{ $stat->kills }}</td>
         <td>{{ $stat->assists }}</td>
         <td>{{ $stat->damage }}</td>
@@ -36,6 +34,19 @@
         <td>{{ $stat->matches_played }}</td>
       </tr>
       @endforeach
+      <tr>
+        <td><strong>Total</strong></td>
+        <td>{{ $stats->sum('kills') }}</td>
+        <td>{{ $stats->sum('assists') }}</td>
+        <td>{{ $stats->sum('damage') }}</td>
+        <td>{{ $stats->sum('survived_minutes') }}</td>
+        <td>{{ $stats->sum('rescues') }}</td>
+        <td>{{ $stats->sum('call_back') }}</td>
+        <td>{{ $stats->sum('score') }}</td>
+        <td>{{ $stats->sum('mvp_count') }}</td>
+        <td>{{ $stats->sum('coffee_breaks') }}</td>
+        <td>{{ $stats->sum('matches_played') }}</td>
+      </tr>
     </tbody>
   </table>
 @endsection


### PR DESCRIPTION
## Summary
- aggregate weekly stats per player on server side
- display per-player totals without week column

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6865851a59c8832d839e4bd6ebb1a832