### PR TITLE
Fix weekly stats query

### DIFF
--- a/app/Http/Controllers/WeeklyStatController.php
+++ b/app/Http/Controllers/WeeklyStatController.php
@@ -1,24 +1,24 @@
 <?php
 namespace App\Http\Controllers;
 
-use App\Models\WeeklyStat;
+use App\Models\MatchPlayer;
 use Illuminate\Http\Request;
 
 class WeeklyStatController extends Controller {
     public function index()
     {
-        $stats = WeeklyStat::join('players', 'players.id', '=', 'weekly_stats.player_id')
+        $stats = MatchPlayer::join('players', 'players.id', '=', 'match_players.player_id')
             ->selectRaw('players.name as player_name, ' .
-                'SUM(weekly_stats.kills) as kills, ' .
-                'SUM(weekly_stats.assists) as assists, ' .
-                'SUM(weekly_stats.damage) as damage, ' .
-                'SUM(weekly_stats.survived_minutes) as survived_minutes, ' .
-                'SUM(weekly_stats.rescues) as rescues, ' .
-                'SUM(weekly_stats.call_back) as call_back, ' .
-                'SUM(weekly_stats.score) as score, ' .
-                'SUM(weekly_stats.mvp_count) as mvp_count, ' .
-                'SUM(weekly_stats.coffee_breaks) as coffee_breaks, ' .
-                'SUM(weekly_stats.matches_played) as matches_played')
+                'SUM(match_players.kills) as kills, ' .
+                'SUM(match_players.assists) as assists, ' .
+                'SUM(match_players.damage) as damage, ' .
+                'SUM(match_players.survived) as survived_minutes, ' .
+                'SUM(match_players.rescue) as rescues, ' .
+                'SUM(match_players.recall) as call_back, ' .
+                'SUM(match_players.score) as score, ' .
+                'SUM(match_players.mvp) as mvp_count, ' .
+                'SUM(match_players.coffee) as coffee_breaks, ' .
+                'SUM(match_players.played) as matches_played')
             ->groupBy('players.name')
             ->orderBy('players.name')
             ->get();


### PR DESCRIPTION
## Summary
- fix weekly stats query by using `match_players` table

## Testing
- `composer --no-ansi exec phpunit -- --no-coverage` *(fails: composer not installed)*
- `./vendor/bin/phpunit --version` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6865899fc828832da53180a96669b15e